### PR TITLE
Fix formatter bug

### DIFF
--- a/src/Monolog/LogtailHandler.php
+++ b/src/Monolog/LogtailHandler.php
@@ -11,6 +11,8 @@
 
 namespace Logtail\Monolog;
 
+use Monolog\Formatter\FormatterInterface;
+
 /**
  * Sends log to Logtail.
  */
@@ -54,5 +56,10 @@ class LogtailHandler extends \Monolog\Handler\AbstractProcessingHandler {
      */
     protected function getDefaultFormatter(): \Monolog\Formatter\FormatterInterface {
         return new \Logtail\Monolog\LogtailFormatter();
+    }
+
+    public function getFormatter(): FormatterInterface
+    {
+        return $this->getDefaultFormatter();
     }
 }


### PR DESCRIPTION
I've discovered a bug that prevents Logtail from working on my Laravel installation. When there is a Formatter set on the handler instance, that doesn't return JSON, the handler fails. 

I've added a test that demonstrates the issue and a potential fix, which is ignoring any outside formatters and always using the default one. This makes sense to me since the server is expecting the data in a certain format.