### PR TITLE
Avoid deprecated message in PHP 8.2

### DIFF
--- a/src/Monolog/LogtailFormatter.php
+++ b/src/Monolog/LogtailFormatter.php
@@ -27,7 +27,7 @@ class LogtailFormatter extends \Monolog\Formatter\JsonFormatter {
 
     public function formatBatch(array $records): string
     {
-        $normalized = array_values($this->normalize(array_map('self::formatRecord', $records)));
+        $normalized = array_values($this->normalize(array_map('Logtail\Monolog\LogtailFormatter::formatRecord', $records)));
         return $this->toJson($normalized, true);
     }
 


### PR DESCRIPTION
With this change, we avoid the annoying message `Deprecated: Use of "self" in callables is deprecated in vendor/logtail/monolog-logtail/src/Monolog/LogtailFormatter.php on line 30`