### PR TITLE
Add LogtailHandlerBuilder::withEndpoint()

### DIFF
--- a/example-project/README.md
+++ b/example-project/README.md
@@ -16,10 +16,10 @@ This command will install all dependencies from `composer.json` file and lock th
  To run the example application, simply run the following command:
 
 ```bash
-php index.php <source-token>
+php index.php <source-token> <source-endpoint>
 ```
 
-*Don't forget to replace `<source-token>` with your actual source token which you can find by going to logtail.com -> sources -> edit.*
+*Don't forget to replace `<source-token>` with your actual source token, and `<source-endpoint>` with the URL of your ingesting endpoint (eg. `https://in.logs.betterstack.com`), which you can find by going to telemetry.betterstack.com -> sources -> edit.*
 
 You should see the following output:
 ```text
@@ -51,10 +51,14 @@ Now it’s time to create a `Logger` instance and push a `LogtailHandler` handle
 
 ```php
 $logger = new Logger("logtail-source");
-$logger->pushHandler(LogtailHandlerBuilder::withSourceToken("<source-token>")->build());
+$logger->pushHandler(
+  LogtailHandlerBuilder::withSourceToken("<source-token>")
+    ->withEndpoint("<source-endpoint>")
+    ->build()
+);
 ```
 
-Don’t forget to change `<source-token>` to your actual token which you can find in the *Basic information* section when clicking on *Edit* on your select source.
+*Don't forget to replace `<source-token>` with your actual source token, and `<source-endpoint>` with the URL of your ingesting endpoint (eg. `https://in.logs.betterstack.com`), which you can find by going to telemetry.betterstack.com -> sources -> edit.*
 
 Also, make sure that the `Logger` instance is accessible from all the branches of your application in which you wish to use the logger.
 

--- a/example-project/index.php
+++ b/example-project/index.php
@@ -10,14 +10,15 @@ use Monolog\Logger;
 use Logtail\Monolog\LogtailHandlerBuilder;
 
 # Check for arguments
-if($argc != 2){
-    # No argument was provided
-    echo "No source token was provided. Please, run the script as followed:\n php index.php <source-token>\n";
+if($argc != 3){
+    # None or one argument provided
+    echo "Not enough arguments. Please, run the script as followed:\n php index.php <source-token> <source-endpoint>\n e.g. php index.php MySourceToken123 https://s12345.my-logs.bettestackdata.com\n";
     exit;
 }
 
 $logger = new Logger("logtail-source");
 $handler = LogtailHandlerBuilder::withSourceToken($argv[1])
+  ->withEndpoint($argv[2])
   ->withBufferLimit(100)
   ->withFlushIntervalMilliseconds(500)
   ->withExceptionThrowing(true)
@@ -25,7 +26,7 @@ $handler = LogtailHandlerBuilder::withSourceToken($argv[1])
 $logger->pushHandler($handler);
 
 # Below you can see available methods that can be used to send logs to logtail.
-# Each method corresponds to Monologs log level.
+# Each method corresponds to Monolog's log level.
 # You can also add additional context information in form of an array to any logging method and pass it as the
 # second argument of the select method (as shown in the warn() method ).
 
@@ -33,7 +34,7 @@ $logger->pushHandler($handler);
 $logger->debug("Logtail logger is ready!");
 
 # Send information about interesting events using info() method
-$logger->info("An interesting event occured!");
+$logger->info("An interesting event occurred!");
 
 # Send information about normal but significant events using notice() method
 $logger->notice("Sending notice");
@@ -54,10 +55,10 @@ $logger->error("Oops! An runtime ERROR occurred!");
 $logger->critical("Oh no! An critical event occurred!");
 
 # Send an alert message about events for which action must be taken immediately using alert() method
-$logger->alert("Something terrible happend! Imidiate action is required!");
+$logger->alert("Something terrible happened! Immediate action is required!");
 
 # Send an emergency message about events that forced the application to crash using emergency() method 
-$logger->emergency("Application just crashed! Imidiate action is required!");
+$logger->emergency("Application just crashed! Immediate action is required!");
 
 
 echo "All done, you can check your logs in the control panel. \n";

--- a/src/Monolog/LogtailHandlerBuilder.php
+++ b/src/Monolog/LogtailHandlerBuilder.php
@@ -52,7 +52,7 @@ final class LogtailHandlerBuilder
      * @param  string $endpoint
      * @return self   Always returns new immutable instance
      */
-    public function withEndpoint($endpoint): self
+    public function withEndpoint(string $endpoint): self
     {
         $clone = clone $this;
         $clone->endpoint = $endpoint;

--- a/src/Monolog/LogtailHandlerBuilder.php
+++ b/src/Monolog/LogtailHandlerBuilder.php
@@ -47,6 +47,20 @@ final class LogtailHandlerBuilder
     }
 
     /**
+     * Sets the endpoint URL to send logs to.
+     *
+     * @param  string $endpoint
+     * @return self   Always returns new immutable instance
+     */
+    public function withEndpoint($endpoint): self
+    {
+        $clone = clone $this;
+        $clone->endpoint = $endpoint;
+
+        return $clone;
+    }
+
+    /**
      * Sets the minimum logging level at which this handler will be triggered.
      *
      * @param  Level $level


### PR DESCRIPTION
Allows rewriting the endpoint using `LogtailHandlerBuilder`.

This PR is for v3, https://github.com/logtail/monolog-logtail/pull/24 is for v2 (still used in ~40% installations).